### PR TITLE
chore(refactor): split codebase to smaller modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
-use std::collections::HashMap;
-
-use retch::retcher::{ RequestOptions, Retcher, RetcherConfig};
+use retch::retcher::{RequestOptions, Retcher, RetcherConfig};
 use napi_derive::napi;
 
 mod response;
+mod request;
 
 use self::response::RetchResponse;
 
@@ -53,27 +52,6 @@ impl Into<RetcherConfig> for RetcherOptions {
 #[napi(js_name="Retcher")]
 pub struct RetcherWrapper {
   inner: Retcher,
-}
-
-#[derive(Default)]
-#[napi(string_enum)]
-pub enum HttpMethod {
-  #[default]
-  GET,
-  POST,
-  PUT,
-  DELETE,
-  PATCH,
-  HEAD,
-  OPTIONS,
-}
-
-#[derive(Default)]
-#[napi(object)]
-pub struct RequestInit {
-  pub method: Option<HttpMethod>,
-  pub headers: Option<HashMap<String, String>>,
-  pub body: Option<Vec<u8>>,
 }
 
 #[napi]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
-use napi::{bindgen_prelude::Buffer, Env, JsFunction, JsObject, JsString, JsUnknown};
-use reqwest::Response;
 use retch::retcher::{ RequestOptions, Retcher, RetcherConfig};
 use napi_derive::napi;
+
+mod response;
+
+use self::response::RetchResponse;
 
 #[napi(string_enum)]
 pub enum Browser {
@@ -45,59 +47,6 @@ impl Into<RetcherConfig> for RetcherOptions {
       config = config.with_proxy(proxy_url);
     }
     config
-  }
-}
-
-#[napi]
-struct RetchResponse {
-  bytes: Vec<u8>,
-  pub status: u16,
-  pub status_text: String,
-  pub headers: HashMap<String, String>,
-  pub ok: bool,
-}
-
-#[napi]
-impl RetchResponse {
-  async fn from(response: Response) -> Self {
-    let status = response.status().as_u16();
-    let status_text = response.status().canonical_reason().unwrap_or("").to_string();
-    let headers = response.headers().iter().map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap().to_string())).collect();
-    let ok = response.status().is_success();
-    let bytes = response.bytes().await.unwrap().to_vec();
-    Self {
-      bytes,
-      status,
-      status_text,
-      headers,
-      ok,
-    }
-  }
-
-  #[napi]
-  pub fn bytes(&self) -> Buffer {
-    self.bytes.clone().into()
-  }
-
-  #[napi]
-  pub fn text(&self) -> String {
-    // Support non-UTF-8 encodings (from the content-type header, the http-equiv meta tag, etc.)
-    String::from_utf8_lossy(&self.bytes).to_string()
-  }
-
-  #[napi(ts_return_type="any")]
-  pub fn json(&self, env: Env) -> JsUnknown {
-    let text = self.text();
-
-    env.get_global().and_then(
-      |global| global.get_named_property::<JsObject>("JSON")
-    ).and_then(
-      |json| json.get_named_property::<JsFunction>("parse")
-    ).expect("fatal: Couldn't get JSON.parse")
-    .call::<JsString>(
-      None,
-      &[env.create_string_from_std(text).expect("Couldn't create JS string from the response text")],
-    ).expect("fatal: Couldn't parse JSON")
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,51 +3,12 @@ use napi_derive::napi;
 
 mod response;
 mod request;
+mod retcher_builder;
 
+use request::{HttpMethod, RequestInit};
+use retcher_builder::RetcherOptions;
 use self::response::RetchResponse;
 
-#[napi(string_enum)]
-pub enum Browser {
-  Chrome,
-  Firefox,
-}
-
-impl Into<retch::Browser> for Browser {
-  fn into(self) -> retch::Browser {
-    match self {
-      Browser::Chrome => retch::Browser::Chrome,
-      Browser::Firefox => retch::Browser::Firefox,
-    }
-  }
-}
-
-#[derive(Default)]
-#[napi(object)]
-struct RetcherOptions {
-  pub browser: Option<Browser>,
-  pub ignore_tls_errors: Option<bool>,
-  pub vanilla_fallback: Option<bool>,
-  pub proxy_url: Option<String>,
-}
-
-impl Into<RetcherConfig> for RetcherOptions {
-  fn into(self) -> RetcherConfig {
-    let mut config = RetcherConfig::default();
-    if let Some(browser) = self.browser {
-      config = config.with_browser(browser.into());
-    }
-    if let Some(ignore_tls_errors) = self.ignore_tls_errors {
-      config = config.with_ignore_tls_errors(ignore_tls_errors);
-    }
-    if let Some(vanilla_fallback) = self.vanilla_fallback {
-      config = config.with_fallback_to_vanilla(vanilla_fallback);
-    }
-    if let Some(proxy_url) = self.proxy_url {
-      config = config.with_proxy(proxy_url);
-    }
-    config
-  }
-}
 
 #[napi(js_name="Retcher")]
 pub struct RetcherWrapper {
@@ -59,9 +20,10 @@ impl RetcherWrapper {
     #[napi(constructor)]
     pub fn new(options: Option<RetcherOptions>) -> Self {
       let config: RetcherConfig = options.unwrap_or_default().into();
-        Self {
-          inner: config.build(),
-        }
+
+      Self {
+        inner: config.build(),
+      }
     }
 
     #[napi]

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,0 +1,23 @@
+use std::collections::HashMap;
+use napi_derive::napi;
+
+#[derive(Default)]
+#[napi(string_enum)]
+pub enum HttpMethod {
+  #[default]
+  GET,
+  POST,
+  PUT,
+  DELETE,
+  PATCH,
+  HEAD,
+  OPTIONS,
+}
+
+#[derive(Default)]
+#[napi(object)]
+pub struct RequestInit {
+  pub method: Option<HttpMethod>,
+  pub headers: Option<HashMap<String, String>>,
+  pub body: Option<Vec<u8>>,
+}

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+
+use napi::{bindgen_prelude::Buffer, Env, JsFunction, JsObject, JsString, JsUnknown};
+use napi_derive::napi;
+use reqwest::Response;
+
+#[napi]
+pub(crate) struct RetchResponse {
+  bytes: Vec<u8>,
+  pub status: u16,
+  pub status_text: String,
+  pub headers: HashMap<String, String>,
+  pub ok: bool,
+}
+
+#[napi]
+impl RetchResponse {
+  // not the Trait From - this method needs to be async.
+  pub(crate) async fn from(response: Response) -> Self {
+    let status = response.status().as_u16();
+    let status_text = response.status().canonical_reason().unwrap_or("").to_string();
+    let headers = response.headers().iter().map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap().to_string())).collect();
+    let ok = response.status().is_success();
+    let bytes = response.bytes().await.unwrap().to_vec();
+    Self {
+      bytes,
+      status,
+      status_text,
+      headers,
+      ok,
+    }
+  }
+
+  #[napi]
+  pub fn bytes(&self) -> Buffer {
+    self.bytes.clone().into()
+  }
+
+  #[napi]
+  pub fn text(&self) -> String {
+    // Support non-UTF-8 encodings (from the content-type header, the http-equiv meta tag, etc.)
+    String::from_utf8_lossy(&self.bytes).to_string()
+  }
+
+  #[napi(ts_return_type="any")]
+  pub fn json(&self, env: Env) -> JsUnknown {
+    let text = self.text();
+
+    env.get_global().and_then(
+      |global| global.get_named_property::<JsObject>("JSON")
+    ).and_then(
+      |json| json.get_named_property::<JsFunction>("parse")
+    ).expect("fatal: Couldn't get JSON.parse")
+    .call::<JsString>(
+      None,
+      &[env.create_string_from_std(text).expect("Couldn't create JS string from the response text")],
+    ).expect("fatal: Couldn't parse JSON")
+  }
+}

--- a/src/retcher_builder.rs
+++ b/src/retcher_builder.rs
@@ -1,0 +1,45 @@
+use retch::retcher::RetcherConfig;
+use napi_derive::napi;
+
+#[napi(string_enum)]
+pub enum Browser {
+  Chrome,
+  Firefox,
+}
+
+impl Into<retch::Browser> for Browser {
+  fn into(self) -> retch::Browser {
+    match self {
+      Browser::Chrome => retch::Browser::Chrome,
+      Browser::Firefox => retch::Browser::Firefox,
+    }
+  }
+}
+
+#[derive(Default)]
+#[napi(object)]
+pub struct RetcherOptions {
+  pub browser: Option<Browser>,
+  pub ignore_tls_errors: Option<bool>,
+  pub vanilla_fallback: Option<bool>,
+  pub proxy_url: Option<String>,
+}
+
+impl Into<RetcherConfig> for RetcherOptions {
+  fn into(self) -> RetcherConfig {
+    let mut config = RetcherConfig::default();
+    if let Some(browser) = self.browser {
+      config = config.with_browser(browser.into());
+    }
+    if let Some(ignore_tls_errors) = self.ignore_tls_errors {
+      config = config.with_ignore_tls_errors(ignore_tls_errors);
+    }
+    if let Some(vanilla_fallback) = self.vanilla_fallback {
+      config = config.with_fallback_to_vanilla(vanilla_fallback);
+    }
+    if let Some(proxy_url) = self.proxy_url {
+      config = config.with_proxy(proxy_url);
+    }
+    config
+  }
+}


### PR DESCRIPTION
Splits the codebase to separate modules, based on the designation.