### PR TITLE
feat: add `http3` support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,6 +3,7 @@ env:
   DEBUG: napi:*
   APP_NAME: retch-http
   MACOSX_DEPLOYMENT_TARGET: '10.13'
+  RUSTFLAGS: '--cfg reqwest_unstable'
 permissions:
   contents: write
   id-token: write

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
               ln -s /usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/crtbeginS.o /usr/lib/crtbeginS.o &&
               ln -s /usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/crtendS.o /usr/lib/crtendS.o &&
               ln -s /usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/libgcc.a /usr/lib/libgcc.a &&
-              yarn build --target x86_64-unknown-linux-musl
+              RUSTFLAGS="--cfg reqwest_unstable" yarn build --target x86_64-unknown-linux-musl
           - host: macos-latest
             target: aarch64-apple-darwin
             build: yarn build --target aarch64-apple-darwin

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,10 @@ export interface RequestInit {
   method?: HttpMethod
   headers?: Record<string, string>
   body?: Array<number>
+  /** Request timeout in milliseconds. Overrides the Retcher-wide timeout option. */
   timeout?: number
+  /** Force the request to use HTTP/3. If the server doesn't expect HTTP/3, the request will fail. */
+  forceHttp3?: boolean
 }
 export const enum Browser {
   Chrome = 'Chrome',
@@ -29,6 +32,8 @@ export interface RetcherOptions {
   proxyUrl?: string
   /** Default timeout for this Retcher instance in milliseconds. */
   timeout?: number
+  /** Enable HTTP/3 support. */
+  http3?: boolean
 }
 export declare class RetchResponse {
   status: number

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ impl RetcherWrapper {
       let request_options = Some(RequestOptions {
         headers: request_init.as_ref().and_then(|init| init.headers.as_ref()).cloned().unwrap_or_default(),
         timeout: if let Some(timeout) = request_init.as_ref().and_then(|init| init.timeout) { Some(Duration::from_millis(timeout.into())) } else { None },
-        ..RequestOptions::default()
+        http3_prior_knowledge: request_init.as_ref().and_then(|init| init.force_http3).unwrap_or_default(),
       });
 
       let body = request_init.as_ref().and_then(|init| init.body.as_ref()).cloned();

--- a/src/request.rs
+++ b/src/request.rs
@@ -22,4 +22,6 @@ pub struct RequestInit {
   pub body: Option<Vec<u8>>,
   /// Request timeout in milliseconds. Overrides the Retcher-wide timeout option.
   pub timeout: Option<u32>,
+  /// Force the request to use HTTP/3. If the server doesn't expect HTTP/3, the request will fail.
+  pub force_http3: Option<bool>,
 }

--- a/src/retcher_builder.rs
+++ b/src/retcher_builder.rs
@@ -27,6 +27,8 @@ pub struct RetcherOptions {
   pub proxy_url: Option<String>,
   /// Default timeout for this Retcher instance in milliseconds.
   pub timeout: Option<u32>,
+  /// Enable HTTP/3 support.
+  pub http3: Option<bool>,
 }
 
 impl Into<RetcherBuilder> for RetcherOptions {
@@ -46,6 +48,11 @@ impl Into<RetcherBuilder> for RetcherOptions {
     }
     if let Some(timeout) = self.timeout {
       config = config.with_default_timeout(Duration::from_millis(timeout.into()));
+    }
+    if let Some(http3) = self.http3 {
+      if http3 {
+        config = config.with_http3();
+      }
     }
     config
   }


### PR DESCRIPTION
Adds passthrough options for the http3-related retch options.