### PR TITLE
feat: more ergonomic usage of request body (string / buffer)

### DIFF
--- a/__test__/index.spec.mjs
+++ b/__test__/index.spec.mjs
@@ -27,19 +27,33 @@ test('headers work', async (t) => {
   json.headers['Retch-Test'] ? t.pass() : t.fail();
 })
 
-test('request body works', async (t) => {
+test('string request body works', async (t) => {
   const response = await retcher.fetch(
     'https://httpbin.org/post', 
     { 
       method: 'POST',
-      body: [...new TextEncoder().encode('{"Retch-Test":"foořžš"}')],
+      body: '{"Retch-Test":"foořžš"}',
       headers: { 'Content-Type': 'application/json' }
     }
   );
   const json = await response.json();
 
   json.data === '{"Retch-Test":"foořžš"}' ? t.pass() : t.fail();
-})
+});
+
+test('binary request body works', async (t) => {
+  const response = await retcher.fetch(
+    'https://httpbin.org/post', 
+    { 
+      method: 'POST',
+      body: Uint8Array.from([0x52, 0x65, 0x74, 0x63, 0x68, 0x2d, 0x54, 0x65, 0x73, 0x74, 0x3a, 0x66, 0x6f, 0x6f, 0xc5, 0x99, 0xc5, 0xbe, 0xc5, 0xa1]),
+      headers: { 'Content-Type': 'application/json' }
+    }
+  );
+  const json = await response.json();
+
+  t.deepEqual(json.data, 'Retch-Test:foořžš');
+});
 
 test('redirects work by default', async (t) => {
   const response = await retcher.fetch(

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ export const enum HttpMethod {
 export interface RequestInit {
   method?: HttpMethod
   headers?: Record<string, string>
-  body?: Array<number>
+  body?: string | Buffer
   /** Request timeout in milliseconds. Overrides the Retcher-wide timeout option. */
   timeout?: number
   /** Force the request to use HTTP/3. If the server doesn't expect HTTP/3, the request will fail. */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod response;
 mod request;
 mod retcher_builder;
 
-use request::{HttpMethod, RequestInit};
+use request::{serialize_body, HttpMethod, RequestInit};
 use retcher_builder::RetcherOptions;
 use self::response::RetchResponse;
 
@@ -37,6 +37,11 @@ impl RetcherWrapper {
       });
 
       let body = request_init.as_ref().and_then(|init| init.body.as_ref()).cloned();
+
+      let body: Option<Vec<u8>> = match body {
+        Some(body) => Some(serialize_body(body)),
+        None => None,
+      };
 
       let response = match request_init.unwrap_or_default().method.unwrap_or_default() {
         HttpMethod::GET => self.inner.get(url, request_options).await,

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use napi::{bindgen_prelude::Buffer, Either};
 use napi_derive::napi;
 
 #[derive(Default)]
@@ -14,12 +15,19 @@ pub enum HttpMethod {
   OPTIONS,
 }
 
+pub(crate) fn serialize_body(body: Either<String, Buffer>) -> Vec<u8> {
+  match body {
+    Either::A(string) => string.into_bytes(),
+    Either::B(buffer) => buffer.into(),
+  }
+}
+
 #[derive(Default)]
 #[napi(object)]
 pub struct RequestInit {
   pub method: Option<HttpMethod>,
   pub headers: Option<HashMap<String, String>>,
-  pub body: Option<Vec<u8>>,
+  pub body: Option<Either<String, Buffer>>,
   /// Request timeout in milliseconds. Overrides the Retcher-wide timeout option.
   pub timeout: Option<u32>,
   /// Force the request to use HTTP/3. If the server doesn't expect HTTP/3, the request will fail.


### PR DESCRIPTION
Improves the usability of the Node bindings by accepting actual `string` / `TypedArray` types as the request body (instead of a list of numbers representing the bytes).

See tests for usage.